### PR TITLE
[groot-docker-enter] pass in a custom name, use a named prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,9 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Unreleased]
-### Added
-- ...
-
-### Changed
 - [groot-docker-build] install networking tools in the image - iproute2, iputils-ping and net-tools
+- [groot-docker-enter] customised prompt that reflects the container name
+- [groot-docker-enter] command line option for customising the container name
 
 ## [0.3.2] - 2020-12-30
 - [groot-docker-enter] pass in the user's ssh environment to the container
@@ -18,25 +16,24 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - [groot-docker-build] use temp dirs to avoid creating unnecessary contexts
 
 ## [0.3.0] - 2020-12-14
-### Added
 - added groot-docker-build and groot-docker-enter
 
 ## [0.2.1] - 2020-06-25
-### Changed
 - bugfix for argparse, is now in python3
 
 ## [0.2.0] - 2020-06-25
-### Added
 - upgraded to python3
 
 ## [0.1.1] - 2017-01-31
-### Changed
 - cfind -> groot-cfind
 
 ## [0.1.0] - 2017-01-31
-### Added
 - cfind added
 
-[Unreleased]: https://github.com/stonier/groot_tools/compare/0.1.1...HEAD
-[0.1.0]: https://github.com/stonier/groot_tools/compare/0.1.0...0.1.1
+[Unreleased]: https://github.com/stonier/groot_tools/compare/0.3.2...HEAD
+[0.3.2]: https://github.com/stonier/groot_tools/compare/0.3.1...0.3.2
+[0.3.1]: https://github.com/stonier/groot_tools/compare/0.3.0...0.3.1
+[0.3.0]: https://github.com/stonier/groot_tools/compare/0.2.1...0.3.0
+[0.2.1]: https://github.com/stonier/groot_tools/compare/0.2.0...0.2.1
+[0.1.1]: https://github.com/stonier/groot_tools/compare/0.1.0...0.1.1
 [0.1.0]: https://github.com/stonier/groot_tools/compare/97851767bb617e1ab5e3a1fbf379242c75b0d0e2...0.1.0

--- a/scripts/groot-docker-enter
+++ b/scripts/groot-docker-enter
@@ -51,6 +51,7 @@ show_help ()
   pretty_print "    Required Options:"
   pretty_print "        --distro=<distro>       : image name (e.g. 'bionic')"
   pretty_print "        --workspace=<workspace> : worskpace dir (e.g. /mnt/workspaces/foo)"
+  pretty_print "        --name=<name>           : container name (default, uses trailing workspace dir)"
   pretty_print ""
   pretty_print "    Options:"
   pretty_print "        --help : show this help message"
@@ -76,6 +77,10 @@ case $i in
     WORKSPACE="${i#*=}"
     shift
     ;;
+    -n=*|--name=*)
+    CONTAINER_NAME="${i#*=}"
+    shift
+    ;;
     *)
        # unknown option
     ;;
@@ -99,12 +104,15 @@ if [ -z "${WORKSPACE}" ]; then
   exit 1
 fi
 
+if [ -z "${CONTAINER_NAME}" ]; then
+  CONTAINER_NAME="$(basename ${WORKSPACE})"
+fi
+
 ##############################################################################
 # Variables
 ##############################################################################
 
 DOCKER_IMAGE=groot:${DISTRO}
-CONTAINER_NAME="$(basename ${WORKSPACE})"
 TARGET_WORKSPACE=/home/${USER}/workspace
 MOUNT_OPTIONS="--mount src=${WORKSPACE},target=${TARGET_WORKSPACE},type=bind"
 GL_SERVER_OPTIONS="--env=DISPLAY --runtime=nvidia --volume /tmp/.X11-unix:/tmp/.X11-unix:ro"
@@ -133,7 +141,8 @@ pretty_print ""
 ##############################################################################
 
 if [ ! -z "${EXITED_CONTAINER_ID}" ]; then
-  pretty_print "Start session with container '${CONTAINER_NAME}'"
+  pretty_print "Start an interactive session with existing container '${CONTAINER_NAME}'"
+  echo "  docker container start -i ${EXITED_CONTAINER_ID}"
   docker container start -i ${EXITED_CONTAINER_ID}
 elif [ ! -z "${RUNNING_CONTAINER_ID}" ]; then
   pretty_print "Attach to running session with container '${CONTAINER_NAME}'"
@@ -145,8 +154,19 @@ else
   #   -i  : interactively run the image in a container 
   #   -rm : remove the container on exit, this loses changes!
   #   -t  : attach a pseudo tty, needed for e.g. stdin/stdout, vim etc
-  pretty_print "Create/Start container '${DOCKER_IMAGE}'->'${CONTAINER_NAME}'"
-  echo "docker container run ${GL_SERVER_OPTIONS} ${MOUNT_OPTIONS} -i -t ${DOCKER_IMAGE}"
-  docker container run ${SSH_OPTIONS} ${GL_SERVER_OPTIONS} ${MOUNT_OPTIONS} -i -t --name ${CONTAINER_NAME} ${DOCKER_IMAGE}
+  pretty_print "Create a shiny new container: 'image:${DOCKER_IMAGE}'->'container:${CONTAINER_NAME}'"
+  echo "  docker container create ${SSH_OPTIONS} ${GL_SERVER_OPTIONS} ${MOUNT_OPTIONS} -i -t --name ${CONTAINER_NAME} ${DOCKER_IMAGE}"
+  docker container create ${SSH_OPTIONS} ${GL_SERVER_OPTIONS} ${MOUNT_OPTIONS} -i -t --name ${CONTAINER_NAME} ${DOCKER_IMAGE} > /dev/null
+  CONTAINER_ID=`docker ps -aqf name=${CONTAINER_NAME}`
+  pretty_print "Add a custom prompt (user@${CONTAINER_NAME} -> ~/.bash_profile)"
+  echo "  docker container start ${CONTAINER_ID}"
+  docker container start ${CONTAINER_ID} > /dev/null
+  echo "  docker container exec ${CONTAINER_ID} bash -c \"echo \"export PS1='\[\033[01;32m\]\u@${CONTAINER_NAME}\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '\" >> /home/${USER}/.bash_profile\""
+  docker container exec ${CONTAINER_ID} bash -c "echo \"export PS1='\[\033[01;32m\]\u@${CONTAINER_NAME}\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '\" >> /home/${USER}/.bash_profile"
+  # Need to stop so the interactive session runs all the login scripts (incl. this .bash_profile)
+  echo "  docker container stop ${CONTAINER_ID}"
+  docker container stop ${CONTAINER_ID} > /dev/null
+  pretty_print "Start an interactive session"
+  echo "  docker container start -i ${CONTAINER_ID}"
+  docker container start -i ${CONTAINER_ID}
 fi
-


### PR DESCRIPTION
Enhancements for `groot-docker-enter`:

* Customise the container prompt to be more useful for hoomans, i.e. `$USER@$CONTAINER_NAME` instead of `$USER@$CONTAINER_ID`
* Allow a user to specify a container name via `--name`

This allows folder reuse across multiple containers, e.g.
```
$ groot-docker-enter --distro=focal --name=launch1 --workspace=/mnt/mervin/workspaces/devel/launch/
...
$ groot-docker-enter --distro=focal --name=launch2 --workspace=/mnt/mervin/workspaces/devel/launch/
...
$  docker container ls -a
CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS                         PORTS               NAMES
2b0dc22ff810        groot:focal         "/bin/bash --login -i"   5 days ago          Exited (0) 2 hours ago                             launch2
63692a8efc89        groot:focal         "/bin/bash --login -i"   5 days ago          Exited (0) 3 hours ago                             launch1
```

